### PR TITLE
Add registration for optional types

### DIFF
--- a/pipeline/include/cvs/pipeline/tbb/tbbOverwriteNode.hpp
+++ b/pipeline/include/cvs/pipeline/tbb/tbbOverwriteNode.hpp
@@ -6,7 +6,7 @@
 
 namespace cvs::pipeline::tbb {
 template <NodeType Type, typename T>
-class TbbOverwriteNode : public TbbBufferTemplateNode<Type, ::tbb::flow::buffer_node, T> {
+class TbbOverwriteNode : public TbbBufferTemplateNode<Type, ::tbb::flow::overwrite_node, T> {
  public:
   static auto make(common::Config&, IExecutionGraphPtr graph, std::shared_ptr<T>) {
     if (auto g = std::dynamic_pointer_cast<TbbFlowGraph>(graph))
@@ -15,7 +15,7 @@ class TbbOverwriteNode : public TbbBufferTemplateNode<Type, ::tbb::flow::buffer_
   }
 
   TbbOverwriteNode(TbbFlowGraphPtr graph)
-      : TbbBufferTemplateNode<Type, ::tbb::flow::buffer_node, T>(graph) {}
+      : TbbBufferTemplateNode<Type, ::tbb::flow::overwrite_node, T>(graph) {}
 };
 
 template <typename T>

--- a/test/moduletest/modulemanagertest.cpp
+++ b/test/moduletest/modulemanagertest.cpp
@@ -38,6 +38,14 @@ TEST(ModuleManagerTest, testPipeline) {
   auto cfg_root_opt = cvs::common::Config::make(std::move(config_str));
   ASSERT_TRUE(cfg_root_opt.has_value());
 
+  std::string node_cfg_str = R"({
+  "name" : "TestName",
+  "element" : "TestElement"
+})";
+
+  auto node_cfg = common::Config::make(std::move(node_cfg_str));
+  ASSERT_TRUE(node_cfg.has_value());
+
   cvs::logger::initLoggers(*cfg_root_opt);
 
   auto manager = cvs::pipeline::impl::ModuleManager::make(*cfg_root_opt);
@@ -47,20 +55,15 @@ TEST(ModuleManagerTest, testPipeline) {
   IExecutionGraphPtr graph = factory->create<IExecutionGraphUPtr>(TbbDefaultName::graph).value_or(nullptr);
   ASSERT_NE(nullptr, graph);
 
-  auto a_node =
-      factory->create<IExecutionNodeUPtr>("A"s, TbbDefaultName::source, *cfg_root_opt, graph).value_or(nullptr);
-  auto b_node =
-      factory->create<IExecutionNodeUPtr>("B"s, TbbDefaultName::function, *cfg_root_opt, graph).value_or(nullptr);
-  auto c_node =
-      factory->create<IExecutionNodeUPtr>("C"s, TbbDefaultName::function, *cfg_root_opt, graph).value_or(nullptr);
-  auto d_node =
-      factory->create<IExecutionNodeUPtr>("D"s, TbbDefaultName::function, *cfg_root_opt, graph).value_or(nullptr);
-  auto e_node =
-      factory->create<IExecutionNodeUPtr>("E"s, TbbDefaultName::function, *cfg_root_opt, graph).value_or(nullptr);
+  auto a_node = factory->create<IExecutionNodeUPtr>("A"s, TbbDefaultName::source, *node_cfg, graph).value_or(nullptr);
+  auto b_node = factory->create<IExecutionNodeUPtr>("B"s, TbbDefaultName::function, *node_cfg, graph).value_or(nullptr);
+  auto c_node = factory->create<IExecutionNodeUPtr>("C"s, TbbDefaultName::function, *node_cfg, graph).value_or(nullptr);
+  auto d_node = factory->create<IExecutionNodeUPtr>("D"s, TbbDefaultName::function, *node_cfg, graph).value_or(nullptr);
+  auto e_node = factory->create<IExecutionNodeUPtr>("E"s, TbbDefaultName::function, *node_cfg, graph).value_or(nullptr);
 
   auto bc_node =
-      factory->create<IExecutionNodeUPtr>("A"s, TbbDefaultName::broadcast_out, *cfg_root_opt, graph).value_or(nullptr);
-  auto j_node = factory->create<IExecutionNodeUPtr>("D"s, TbbDefaultName::join, *cfg_root_opt, graph).value_or(nullptr);
+      factory->create<IExecutionNodeUPtr>("A"s, TbbDefaultName::broadcast_out, *node_cfg, graph).value_or(nullptr);
+  auto j_node = factory->create<IExecutionNodeUPtr>("D"s, TbbDefaultName::join, *node_cfg, graph).value_or(nullptr);
 
   ASSERT_NE(nullptr, a_node);
   ASSERT_NE(nullptr, b_node);

--- a/test/tbbtest/src/graphtest.cpp
+++ b/test/tbbtest/src/graphtest.cpp
@@ -18,7 +18,10 @@ class AElement : public IElement<int()> {
   static auto make(common::Config&) {
     auto e = std::make_unique<AElement>();
 
-    EXPECT_CALL(*e, process()).Times(2).WillRepeatedly([]() { return 10; });
+    EXPECT_CALL(*e, process()).Times(2).WillRepeatedly([]() {
+      //
+      return 10;
+    });
 
     EXPECT_CALL(*e, isStopped()).WillOnce([]() { return false; }).WillOnce([]() { return true; });
 
@@ -161,7 +164,12 @@ TEST_F(GraphTest, branch_graph) {
   //       |
   //       E
 
-  common::Config cfg;
+  std::string cfg_str = R"({
+  "name" : "TestName",
+  "element" : "TestElement"
+})";
+
+  common::Config cfg = common::Config::make(std::move(cfg_str)).value();
 
   IExecutionGraphPtr graph = factory->create<IExecutionGraphUPtr>(TbbDefaultName::graph).value_or(nullptr);
   ASSERT_NE(nullptr, graph);
@@ -203,7 +211,12 @@ TEST_F(GraphTest, branch_graph) {
 }
 
 TEST_F(GraphTest, multifunctional) {
-  common::Config cfg;
+  std::string cfg_str = R"({
+  "name" : "TestName",
+  "element" : "TestElement"
+})";
+
+  common::Config cfg = common::Config::make(std::move(cfg_str)).value();
 
   IExecutionGraphPtr graph = factory->create<IExecutionGraphUPtr>(TbbDefaultName::graph).value_or(nullptr);
   ASSERT_NE(nullptr, graph);

--- a/test/tbbtest/src/guiTest.cpp
+++ b/test/tbbtest/src/guiTest.cpp
@@ -100,12 +100,12 @@ TEST_F(GuiTest, in_out) {
   //     |   |
   //    Buf Buf
 
-  std::string config_1_json = R"json({ "value": 1 })json";
-  std::string config_3_json = R"json({ "value": 3 })json";
+  std::string config_1_json = R"json({ "value": 1, "name" : "TestName", "element" : "TestElement" })json";
+  std::string config_3_json = R"json({ "value": 3, "name" : "TestName", "element" : "TestElement" })json";
 
   auto           cfg_1 = cvs::common::Config::make(std::move(config_1_json)).value();
   auto           cfg_3 = cvs::common::Config::make(std::move(config_3_json)).value();
-  common::Config cfg;
+  common::Config cfg   = cvs::common::Config::make(R"({"name" : "TestName", "element" : "TestElement"})").value();
 
   IExecutionGraphPtr graph = factory->create<IExecutionGraphUPtr>(TbbDefaultName::graph).value_or(nullptr);
   ASSERT_NE(nullptr, graph);


### PR DESCRIPTION
Хелперы для tuple аргументов и возвращаемых типов переименованы в <Element>.in[N] и <Element>.out[N] соответственно.

Исправлена бага с override нодой.

Регистрация сервисных нод для std::optional<T> и отдельно для вложенного типа (T). Необходимо для multifunctional_node.
Если элемент возвращает std::optional и создан для multifunctional_node - возвращение std::nullopt не приводит к пекредаче значения. Если значение есть - передается дальше по пайплайну. Тип значения, передаваемого из multifunctional_node T (выводится из возвращаемого типа элемента: std::optional<T>).
std::tuple<std::optional<T>...> интерпретируется как N выходов ноды (каждый элемент tuple проверятся отдельно).

TODO:
Т.к. не менялся интерфейс IElement не все возмолжные usecase для multifunctional_node доступны. Невозможно вернуть произвольное число значений для каждого из выходов (например есть std::tuple<std::optional<int>, std::tuple<std::optional<double>> и за один вызов элемента возвращаем 5 int и 1 double  в произвольном порядке).